### PR TITLE
Allow unused imports

### DIFF
--- a/inventory/src/lib.rs
+++ b/inventory/src/lib.rs
@@ -9,7 +9,9 @@ mod semver;
 mod sha2;
 mod unit;
 
+#[allow(unused_imports)]
 #[cfg(feature = "semver")]
 pub use semver::*;
+#[allow(unused_imports)]
 #[cfg(feature = "sha2")]
 pub use sha2::*;


### PR DESCRIPTION
These don't seem to actually be necessary (as the `mod semver` and `mod sha2` will use them when these features are enabled)?