### PR TITLE
Make Artifact#metadata optional

### DIFF
--- a/inventory-cli/src/main.rs
+++ b/inventory-cli/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
                 arch: args.arch,
                 url: args.url,
                 checksum: args.checksum,
-                metadata: Some(()),
+                metadata: None,
             });
 
             std::fs::write(&args.path, inventory.to_string()).unwrap();

--- a/inventory-cli/src/main.rs
+++ b/inventory-cli/src/main.rs
@@ -44,7 +44,7 @@ fn main() {
                 arch: args.arch,
                 url: args.url,
                 checksum: args.checksum,
-                metadata: (),
+                metadata: Some(()),
             });
 
             std::fs::write(&args.path, inventory.to_string()).unwrap();

--- a/inventory/src/artifact.rs
+++ b/inventory/src/artifact.rs
@@ -13,8 +13,8 @@ pub struct Artifact<V, D, M> {
     pub url: String,
     #[serde(bound = "D: Digest")]
     pub checksum: Checksum<D>,
-    #[serde(bound = "M: Serialize + DeserializeOwned")]
-    pub metadata: M,
+    #[serde(default, bound = "M: Serialize + DeserializeOwned")]
+    pub metadata: Option<M>,
 }
 
 impl<V, D, M> PartialEq for Artifact<V, D, M>

--- a/inventory/src/inventory.rs
+++ b/inventory/src/inventory.rs
@@ -9,7 +9,9 @@ use std::str::FromStr;
 /// Represents an inventory of artifacts.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Inventory<V, D, M> {
-    #[serde(bound = "V: Serialize + DeserializeOwned, D: Digest, M: Serialize + DeserializeOwned")]
+    #[serde(
+        bound = "V: Serialize + DeserializeOwned, D: Digest, M: Serialize + DeserializeOwned + Default"
+    )]
     pub artifacts: Vec<Artifact<V, D, M>>,
 }
 
@@ -55,7 +57,7 @@ impl<V, D, M> FromStr for Inventory<V, D, M>
 where
     V: Serialize + DeserializeOwned,
     D: Digest,
-    M: Serialize + DeserializeOwned,
+    M: Serialize + DeserializeOwned + Default,
 {
     type Err = ParseInventoryError;
 
@@ -68,7 +70,7 @@ impl<V, D, M> std::fmt::Display for Inventory<V, D, M>
 where
     V: Serialize + DeserializeOwned,
     D: Digest,
-    M: Serialize + DeserializeOwned,
+    M: Serialize + DeserializeOwned + Default,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(&toml::to_string(self).unwrap())
@@ -122,7 +124,7 @@ mod test {
             arch,
             url: "https://example.com".to_string(),
             checksum: BogusDigest::checksum("cafebabe"),
-            metadata: (),
+            metadata: Some(()),
         }
     }
 }

--- a/inventory/src/inventory.rs
+++ b/inventory/src/inventory.rs
@@ -124,7 +124,7 @@ mod test {
             arch,
             url: "https://example.com".to_string(),
             checksum: BogusDigest::checksum("cafebabe"),
-            metadata: Some(()),
+            metadata: None,
         }
     }
 }

--- a/inventory/src/version.rs
+++ b/inventory/src/version.rs
@@ -1,5 +1,5 @@
 pub trait ArtifactRequirement<V, M> {
-    fn satisfies_metadata(&self, metadata: &M) -> bool;
+    fn satisfies_metadata(&self, metadata: &Option<M>) -> bool;
     fn satisfies_version(&self, version: &V) -> bool;
 }
 
@@ -11,7 +11,7 @@ impl<V, M, VR> ArtifactRequirement<V, M> for VR
 where
     VR: VersionRequirement<V>,
 {
-    fn satisfies_metadata(&self, _: &M) -> bool {
+    fn satisfies_metadata(&self, _: &Option<M>) -> bool {
         true
     }
 


### PR DESCRIPTION
I'm guessing a lot of users (including all current consumers of inventory code) will not need metadata -- so would it perhaps make sense if this the metadata field is optional?